### PR TITLE
Enhance train_nn docs and nn_fit print naming consistency

### DIFF
--- a/R/generalized-nn-fitds.R
+++ b/R/generalized-nn-fitds.R
@@ -6,6 +6,9 @@
 #' lazy loading are handled by `torch::dataloader()`, making this method
 #' well-suited for large datasets that do not fit entirely in memory.
 #'
+#' Architecture configuration follows the same contract as other `train_nn()`
+#' methods via `architecture = nn_arch(...)` (or legacy `arch = ...`).
+#'
 #' Labels are taken from the second element of each dataset item (i.e.
 #' `dataset[[i]][[2]]`), so `y` is ignored. When the label is a scalar tensor,
 #' a classification task is assumed and `n_classes` must be supplied. The loss
@@ -13,8 +16,6 @@
 #'
 #' Fitted values are **not** cached in the returned object. Use
 #' [predict.nn_fit_ds()] with `newdata` to obtain predictions after training.
-#'
-#' @return An object of class `c("nn_fit_ds", "nn_fit")`.
 #'
 #' @examples
 #' \donttest{
@@ -75,6 +76,7 @@ train_nn.dataset =
         output_activation = NULL,
         bias = TRUE,
         arch = NULL,
+        architecture = NULL,
         epochs = 100,
         batch_size = 32,
         penalty = 0,
@@ -95,9 +97,7 @@ train_nn.dataset =
         cli::cli_abort("Package {.pkg torch} is required but not installed.")
     }
 
-    if (!is.null(arch) && !inherits(arch, "nn_arch")) {
-        cli::cli_abort("{.arg arch} must be an {.cls nn_arch} object created with {.fn nn_arch}.")
-    }
+    arch = .resolve_train_architecture(architecture = architecture, arch = arch)
 
     if (!is.null(y)) {
         cli::cli_warn("{.arg y} is ignored when {.arg x} is a dataset. Labels come from the dataset itself.")

--- a/R/print-gen-nn.R
+++ b/R/print-gen-nn.R
@@ -34,8 +34,8 @@ print.nn_fit = function(x, ...) {
             "Hidden Layer Units",
             "Number of Hidden Layers",
             "Pred. Type",
-            "n_predictors",
-            "n_response",
+            "n_inputs",
+            "n_outputs",
             "reg.",
             "Device"
         ),
@@ -103,7 +103,8 @@ print.nn_fit = function(x, ...) {
             "before_output_transform",
             "after_output_transform",
             "last_layer_args",
-            "input_transform"
+            "input_transform",
+            "use_namespace"
         ),
         res = if (is.null(arch)) {
             rep("N/A", 10L)
@@ -117,7 +118,8 @@ print.nn_fit = function(x, ...) {
                 flag(arch$before_output_transform),
                 flag(arch$after_output_transform),
                 if (length(arch$last_layer_args) > 0) "yes" else "N/A",
-                flag(arch$input_transform)
+                flag(arch$input_transform),
+                as.character(isTRUE(arch$use_namespace))
             )
         },
         stringsAsFactors = FALSE

--- a/man/gen-nn-predict.Rd
+++ b/man/gen-nn-predict.Rd
@@ -21,12 +21,13 @@
 \item \code{predict.nn_fit()}: a numeric \code{matrix} or coercible object.
 \item \code{predict.nn_fit_tab()}: a \code{data.frame} with the same columns used during
 training; preprocessing is applied automatically via \code{hardhat::forge()}.
+\item \code{predict.nn_fit_ds()}: a \code{torch} \code{dataset}, numeric \code{array}, \code{matrix}, or
+\code{data.frame}.
 If \code{NULL}, the cached fitted values from training are returned (not
 available for \code{type = "prob"}).
 }}
 
-\item{new_data}{Alternative spelling of \code{newdata} following the \code{hardhat}
-convention. Ignored when \code{newdata} is supplied.}
+\item{new_data}{Legacy alias for \code{newdata}. Retained for compatibility.}
 
 \item{type}{Character. Output type:
 \itemize{

--- a/man/gen-nn-predict.Rd
+++ b/man/gen-nn-predict.Rd
@@ -14,19 +14,15 @@
 \method{predict}{nn_fit_ds}(object, newdata = NULL, new_data = NULL, type = "response", ...)
 }
 \arguments{
-\item{object}{A fitted model object returned by \code{\link[=train_nn]{train_nn()}}. For
-\code{predict.nn_fit_ds()}, this must be of class \code{"nn_fit_ds"}.}
+\item{object}{A fitted model object returned by \code{\link[=train_nn]{train_nn()}}.}
 
 \item{newdata}{New predictor data. Accepted forms depend on the method:
 \itemize{
 \item \code{predict.nn_fit()}: a numeric \code{matrix} or coercible object.
 \item \code{predict.nn_fit_tab()}: a \code{data.frame} with the same columns used during
 training; preprocessing is applied automatically via \code{hardhat::forge()}.
-\item \code{predict.nn_fit_ds()}: a \code{torch} \code{dataset} object or a numeric matrix /
-data frame. When \code{NULL}, an error is raised (fitted values are not cached
-for dataset fits).
-If \code{NULL} for \code{predict.nn_fit()} / \code{predict.nn_fit_tab()}, the cached fitted
-values from training are returned (not available for \code{type = "prob"}).
+If \code{NULL}, the cached fitted values from training are returned (not
+available for \code{type = "prob"}).
 }}
 
 \item{new_data}{Alternative spelling of \code{newdata} following the \code{hardhat}
@@ -34,8 +30,8 @@ convention. Ignored when \code{newdata} is supplied.}
 
 \item{type}{Character. Output type:
 \itemize{
-\item \code{"response"} (default): predicted class labels (factor) for classification,
-or a numeric vector / matrix for regression.
+\item \code{"response"} (default): predicted class labels (factor) for
+classification, or a numeric vector / matrix for regression.
 \item \code{"prob"}: a numeric matrix of class probabilities (classification only).
 }}
 

--- a/man/gen-nn-train.Rd
+++ b/man/gen-nn-train.Rd
@@ -98,6 +98,7 @@ train_nn(x, ...)
   bias = TRUE,
   arch = NULL,
   architecture = NULL,
+  flatten_input = NULL,
   epochs = 100,
   batch_size = 32,
   penalty = 0,
@@ -123,6 +124,7 @@ factor / matrix of outcomes, or a formula describing the outcome–predictor
 relationship within \code{x}.
 \item \code{formula}: combined with \code{data} and preprocessed via \code{hardhat::mold()}.
 \item \code{dataset}: a \code{torch} dataset object; batched via \code{torch::dataloader()}.
+This is the recommended interface for sequence/time-series and image data.
 }}
 
 \item{...}{Additional arguments passed to specific methods.}
@@ -201,6 +203,10 @@ matrices in the returned object under \verb{$cached_weights}. Default \code{FALS
 
 \item{data}{A data frame. Required when \code{x} is a formula.}
 
+\item{flatten_input}{Logical or \code{NULL} (dataset method only). Controls whether
+each batch/sample is flattened to 2D before entering the model. \code{NULL}
+(default) auto-selects: \code{TRUE} when \code{architecture = NULL}, otherwise \code{FALSE}.}
+
 \item{n_classes}{Positive integer. Number of output classes. Required when
 \code{x} is a \code{dataset} with scalar (classification) labels; ignored otherwise.}
 }
@@ -255,6 +261,22 @@ training ran to completion
 \item \code{arch} — the \code{nn_arch} object used, or \code{NULL}
 }
 }
+\section{Supported tasks and input formats}{
+
+\code{train_nn()} is task-agnostic by design (no explicit \code{task} argument).
+Task behavior is determined by your input interface and architecture:
+\itemize{
+\item \strong{Tabular data}: use \code{matrix}, \code{data.frame}, or \code{formula} methods.
+\item \strong{Time series}: use the \code{dataset} method with per-item tensors shaped as
+\verb{[time, features]} (or your preferred convention) and a recurrent
+architecture via \code{\link[=nn_arch]{nn_arch()}}.
+\item \strong{Image classification}: use the \code{dataset} method with per-item tensors
+shaped for your first layer (commonly \verb{[channels, height, width]} for
+\code{torch::nn_conv2d}). If your source arrays are channel-last, reorder in the
+dataset or via \code{input_transform}.
+}
+}
+
 \section{Matrix method}{
 
 When \code{x} is supplied as a raw numeric matrix, no preprocessing is applied.
@@ -282,6 +304,8 @@ well-suited for large datasets that do not fit entirely in memory.
 
 Architecture configuration follows the same contract as other \code{train_nn()}
 methods via \code{architecture = nn_arch(...)} (or legacy \code{arch = ...}).
+For non-tabular inputs (time series, images), set \code{flatten_input = FALSE} to
+preserve tensor dimensions expected by recurrent or convolutional layers.
 
 Labels are taken from the second element of each dataset item (i.e.
 \code{dataset[[i]][[2]]}), so \code{y} is ignored. When the label is a scalar tensor,

--- a/man/gen-nn-train.Rd
+++ b/man/gen-nn-train.Rd
@@ -20,6 +20,7 @@ train_nn(x, ...)
   output_activation = NULL,
   bias = TRUE,
   arch = NULL,
+  architecture = NULL,
   early_stopping = NULL,
   epochs = 100,
   batch_size = 32,
@@ -44,6 +45,7 @@ train_nn(x, ...)
   output_activation = NULL,
   bias = TRUE,
   arch = NULL,
+  architecture = NULL,
   early_stopping = NULL,
   epochs = 100,
   batch_size = 32,
@@ -68,6 +70,7 @@ train_nn(x, ...)
   output_activation = NULL,
   bias = TRUE,
   arch = NULL,
+  architecture = NULL,
   early_stopping = NULL,
   epochs = 100,
   batch_size = 32,
@@ -94,6 +97,7 @@ train_nn(x, ...)
   output_activation = NULL,
   bias = TRUE,
   arch = NULL,
+  architecture = NULL,
   epochs = 100,
   batch_size = 32,
   penalty = 0,
@@ -146,7 +150,10 @@ Defaults to \code{NULL} (no activation / linear output).}
 
 \item{bias}{Logical. Whether to include bias terms in each layer. Default \code{TRUE}.}
 
-\item{arch}{An \code{\link[=nn_arch]{nn_arch()}} object specifying a custom architecture. Default
+\item{arch}{Backward-compatible alias for \code{architecture}. If both are supplied,
+they must be identical.}
+
+\item{architecture}{An \code{\link[=nn_arch]{nn_arch()}} object specifying a custom architecture. Default
 \code{NULL}, which falls back to a standard feed-forward network.}
 
 \item{early_stopping}{An \code{\link[=early_stop]{early_stop()}} object specifying early stopping
@@ -206,8 +213,6 @@ An object of class \code{"nn_fit"}, or one of its subclasses:
 
 All subclasses share a common structure. See \strong{Details} for the list of
 components.
-
-An object of class \code{c("nn_fit_ds", "nn_fit")}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
@@ -216,8 +221,15 @@ An object of class \code{c("nn_fit_ds", "nn_fit")}.
 user-defined architecture via \code{\link[=nn_arch]{nn_arch()}}. Dispatch is based on the class
 of \code{x}.
 
+Recommended workflow:
+\enumerate{
+\item Define architecture with \code{\link[=nn_arch]{nn_arch()}} (optional).
+\item Train with \code{train_nn()}.
+\item Predict with \code{\link[=predict.nn_fit]{predict.nn_fit()}}.
+}
+
 All methods delegate to a shared implementation core after preprocessing.
-When \code{arch = NULL}, the model falls back to a plain feed-forward neural network
+When \code{architecture = NULL}, the model falls back to a plain feed-forward neural network
 (\code{nn_linear}) architecture.
 }
 \details{
@@ -267,6 +279,9 @@ which the formula is evaluated. Preprocessing is handled by \code{hardhat::mold(
 Trains a neural network directly on a \code{torch} dataset object. Batching and
 lazy loading are handled by \code{torch::dataloader()}, making this method
 well-suited for large datasets that do not fit entirely in memory.
+
+Architecture configuration follows the same contract as other \code{train_nn()}
+methods via \code{architecture = nn_arch(...)} (or legacy \code{arch = ...}).
 
 Labels are taken from the second element of each dataset item (i.e.
 \code{dataset[[i]][[2]]}), so \code{y} is ignored. When the label is a scalar tensor,
@@ -320,6 +335,39 @@ if (torch::torch_is_installed()) {
     model = train_nn(
         x = Sepal.Length ~ .,
         data = iris[, 1:4],
+        epochs = 50
+    )
+
+    # Architecture object (nn_arch -> train_nn)
+    mlp_arch = nn_arch(nn_name = "mlp_model")
+    model = train_nn(
+        x = Sepal.Length ~ .,
+        data = iris[, 1:4],
+        hidden_neurons = c(64, 32),
+        activations = "relu",
+        architecture = mlp_arch,
+        epochs = 50
+    )
+
+    # Custom layer architecture
+    custom_linear = torch::nn_module(
+        "CustomLinear",
+        initialize = function(in_features, out_features, bias = TRUE) {
+            self$layer = torch::nn_linear(in_features, out_features, bias = bias)
+        },
+        forward = function(x) self$layer(x)
+    )
+    custom_arch = nn_arch(
+        nn_name = "custom_linear_mlp",
+        nn_layer = "custom_linear",
+        use_namespace = FALSE
+    )
+    model = train_nn(
+        x = Sepal.Length ~ .,
+        data = iris[, 1:4],
+        hidden_neurons = c(16, 8),
+        activations = "relu",
+        architecture = custom_arch,
         epochs = 50
     )
 

--- a/man/nn_arch.Rd
+++ b/man/nn_arch.Rd
@@ -14,7 +14,8 @@ nn_arch(
   before_output_transform = NULL,
   after_output_transform = NULL,
   last_layer_args = list(),
-  input_transform = NULL
+  input_transform = NULL,
+  use_namespace = TRUE
 )
 }
 \arguments{
@@ -48,18 +49,36 @@ Transforms must therefore be independent of batch size. Safe examples:
 \code{~ .$unsqueeze(2)} (RNN sequence dim), \code{~ .$unsqueeze(1)} (CNN channel dim).
 Avoid transforms that reshape based on \code{.$size(1)} as this will reflect the
 full dataset size, not the mini-batch size.}
+
+\item{use_namespace}{Logical. If \code{TRUE} (default), layer symbols are resolved
+with explicit \verb{torch::} namespace when applicable. Set to \code{FALSE} when using
+custom layers defined in the calling environment.}
 }
 \value{
-An object of class \code{"nn_arch"}, a named list of \code{nn_module_generator()} arguments.
+An object of class \code{c("nn_arch", "kindling_arch")}, implemented as a
+named list of \code{nn_module_generator()} arguments with an \code{"env"} attribute
+capturing the calling environment for custom layer resolution.
 }
 \description{
-\code{nn_arch()} is a helper that bundles \code{nn_module_generator()} arguments into a
-single object passed to \code{train_nn()} via the \code{arch} parameter. All arguments
-mirror those of \code{nn_module_generator()} exactly, including their defaults.
+\code{nn_arch()} defines an architecture specification object consumed by
+\code{\link[=train_nn]{train_nn()}} via \code{architecture} (or legacy \code{arch}).
+
+Conceptual workflow:
+\enumerate{
+\item Define architecture with \code{nn_arch()}.
+\item Train with \verb{train_nn(..., architecture = <nn_arch>)}.
+\item Predict with \code{predict()}.
+}
+
+Architecture fields mirror \code{nn_module_generator()} and are passed through
+without additional branching logic.
 }
 \examples{
 \donttest{
 if (torch::torch_is_installed()) {
+    # Standard architecture object for train_nn()
+    std_arch = nn_arch(nn_name = "mlp_model")
+
     # GRU architecture spec
     gru_arch = nn_arch(
         nn_name = "GRU",
@@ -75,13 +94,27 @@ if (torch::torch_is_installed()) {
         input_transform = ~ .$unsqueeze(2)
     )
 
+    # Custom layer architecture (resolved from calling environment)
+    custom_linear = torch::nn_module(
+        "CustomLinear",
+        initialize = function(in_features, out_features, bias = TRUE) {
+            self$layer = torch::nn_linear(in_features, out_features, bias = bias)
+        },
+        forward = function(x) self$layer(x)
+    )
+    custom_arch = nn_arch(
+        nn_name = "CustomMLP",
+        nn_layer = "custom_linear",
+        use_namespace = FALSE
+    )
+
     model = train_nn(
         Sepal.Length ~ .,
         data = iris[, 1:4],
         hidden_neurons = c(64, 32),
         activations = "relu",
         epochs = 50,
-        arch = gru_arch
+        architecture = gru_arch
     )
 }
 }

--- a/man/train_nn_impl_dataset.Rd
+++ b/man/train_nn_impl_dataset.Rd
@@ -25,6 +25,7 @@ train_nn_impl_dataset(
   device = NULL,
   verbose = FALSE,
   cache_weights = FALSE,
+  flatten_input = TRUE,
   arch = NULL,
   fit_class = "nn_fit_ds"
 )


### PR DESCRIPTION
This PR targets `native-models` and contains commit `670cd43831fcb7dd7678ae603ab0b6be827a1312`.

### Summary
- Enhance documentation for `train_nn()` and `train_nn.dataset()`
- Clarify `flatten_input` behavior and supported input formats
- Update `print.nn_fit()` output labels to match parameter naming changes